### PR TITLE
Fix compilation on macOS

### DIFF
--- a/cpufeature/cpu_x86_linux.c
+++ b/cpufeature/cpu_x86_linux.c
@@ -10,7 +10,18 @@
 #include "cpu_x86.h"
 #include <pthread.h>
 #include <unistd.h>
+
+#ifdef __linux__
 #include <sys/sysinfo.h>
+#endif
+
+#if defined(__DragonFly__) || \
+    defined(__OpenBSD__)   || \
+    defined(__FreeBSD__)   || \
+    defined(__NetBSD__)    || \
+    defined(__APPLE__)
+#include <sys/sysctl.h>
+#endif
 
 void cpuid(int32_t out[4], int32_t eax, int32_t ecx) {
     // For GCC-specific cpuid


### PR DESCRIPTION
Dear Robert,

the recent improvement to support AMD CPUs (#5) didn't take into account that `sys/sysinfo.h` is only available on Linux. By using `sys/sysctl.h` for the Mach family instead, the compilation succeeds again.

This fixes #9.

With kind regards,
Andreas.

cc @drfinkus 